### PR TITLE
[Sikkerhet] Oppdaterer med ny catalog-info.yaml og engelske filnavn

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-/.sikkerhet/ @dagolav
+/.security/ @dagolav

--- a/.security/description.yaml
+++ b/.security/description.yaml
@@ -1,4 +1,3 @@
-version: 3.0
 organization: Land
 product: GeoNorge
 repo_types: [Library]

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -10,29 +10,3 @@ spec:
   lifecycle: "production"
   owner: "datadeling_og_distribusjon"
   system: "geonorge"
----
-apiVersion: "backstage.io/v1alpha1"
-kind: "Group"
-metadata:
-  name: "security_champion_GeoNorgeAPI"
-  title: "Security Champion GeoNorgeAPI"
-spec:
-  type: "security_champion"
-  parent: "land_security_champions"
-  members:
-  - "dagolav"
-  children:
-  - "resource:GeoNorgeAPI"
----
-apiVersion: "backstage.io/v1alpha1"
-kind: "Resource"
-metadata:
-  name: "GeoNorgeAPI"
-  links:
-  - url: "https://github.com/kartverket/GeoNorgeAPI"
-    title: "GeoNorgeAPI på GitHub"
-spec:
-  type: "repo"
-  owner: "security_champion_GeoNorgeAPI"
-  dependencyOf:
-  - "component:GeoNorgeAPI"


### PR DESCRIPTION
Denne PRen oppdaterer `catalog-info.yaml` for å gi entiteter til Backstage. Vi fjerner nå resource og sec. champ hierarkiet. Videre dropper vi å ha versionsnummer i description.yaml